### PR TITLE
Fix for the Circular Progress Indicator Crash Issue

### DIFF
--- a/app/src/main/java/dev/rivu/composeclass1/userslist/ui/Pagination.kt
+++ b/app/src/main/java/dev/rivu/composeclass1/userslist/ui/Pagination.kt
@@ -59,7 +59,7 @@ fun PaginatedUsersListScreen(
                     state.users,
                     state.isPaginationLoading,
                     state.canPaginate,
-                    false,
+                    state.isP2RLoading,
                     modifier = Modifier.fillMaxSize(),
                     fetchNextPage = {
                         viewModel.fetchUsers()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ lifecycle-runtime-ktx = "2.6.2"
 activity-compose = "1.8.2"
 compose-bom = "2023.10.01"
 material2 = "1.5.4"
+material3 = "1.2.0-beta02"
 navigation-compose = "2.7.6"
 paging = "3.3.0-alpha02"
 
@@ -36,7 +37,8 @@ ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-material3 = { group = "androidx.compose.material3", name = "material3" }
+#material3 = { group = "androidx.compose.material3", name = "material3" }
+material3 = { module = "androidx.compose.material3:material3-android", version.ref = "material3" }
 material2 = { group = "androidx.compose.material", name = "material" }
 animation = { group = "androidx.compose.animation", name = "animation" }
 paging-runtime = { module = "androidx.paging:paging-runtime", version.ref="paging" }


### PR DESCRIPTION
@RivuChk 
-  This PR addresses a crash issue that occurs when using the Circular Progress Indicator with Compose BOM version 2023.10.01. 
-  The fix is implemented based on the solution provided in this Stack Overflow answer: https://stackoverflow.com/a/77347462/11576858